### PR TITLE
Fix numbering on README instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,5 @@ Write some code in `axios.js` to remove these errors and restore the basic funct
 
 Check the solution branch for my quick implementation via `git checkout solution`.
 
-1. DO use native JavaScript Promises.
-  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
+1. DO use native JavaScript [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 1. DON'T use jQuery's Promises.


### PR DESCRIPTION
I added a reference to the MDN docs for Promises, but forgot to fix the number/spacing for the instructions.